### PR TITLE
uses predef idents from compiler-libs

### DIFF
--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -19,6 +19,11 @@ open Path
 open Types
 open Btype
 
+let find_ident name =
+  Melange_wrapper.Predef.builtin_idents
+  |> List.find (fun (s, _) -> s = name)
+  |> snd
+
 let builtin_idents = ref []
 
 let wrap create s =
@@ -26,7 +31,7 @@ let wrap create s =
   builtin_idents := (s, id) :: !builtin_idents;
   id
 
-let ident_create = wrap Ident.create_predef
+let ident_create = wrap find_ident
 
 let ident_int = ident_create "int"
 and ident_char = ident_create "char"

--- a/wrapper/melange_wrapper.mli
+++ b/wrapper/melange_wrapper.mli
@@ -1,5 +1,4 @@
-
-
 module Location = Location
 module Misc = Misc
 module Warnings = Warnings
+module Predef = Predef


### PR DESCRIPTION
## Problem

The predef idents from melange are not the same as the ones from `compiler-libs` this leads to problems with Merlin and the LSP because there is `unit/1` and `unit/2`

## Reproduction

This will build but the LSP will say it's invalid code.

```ocaml
let fn = () => ();
let x = fn(Js.log("yo"));
```

## Reported by

Kudos to @coetry to report it