### PR TITLE
Support for non-BuckleScript cppo-directives for verison-comparison

### DIFF
--- a/parsing/rescript_cpp.ml
+++ b/parsing/rescript_cpp.ml
@@ -207,7 +207,7 @@ let semver loc lhs str =
     | `Compatible -> major = l_major
     | `Exact -> lversion = version
 
-(** Specifically and only coerces [Dir_string] on the LHS into a [Dir_tuple] if the RHS is also a [Dir_tuple]. The value on the RHS {e must} be a semver-compatible string, i.e. [OCAML_VERSION]. *)
+(** Specifically and only coerces [Dir_string] on the LHS into a [Dir_tuple] if the RHS is also a [Dir_tuple]. The value on the LHS {e must} be a semver-compatible string, i.e. [OCAML_VERSION]. *)
 let coerce_type (lexbuf : Lexing.lexbuf) (lhs : directive_value) (rhs : directive_value) =
   match lhs, rhs with
   | Dir_string s, Dir_tuple r_els ->

--- a/parsing/rescript_cpp.ml
+++ b/parsing/rescript_cpp.ml
@@ -315,7 +315,7 @@ let directive_parse (token_with_comments : Lexing.lexbuf -> Parser.token) lexbuf
     | _ as e ->
         push e;
         let v = token_value () in
-        (v :: els)
+        parse_tuple (v :: els) ()
   and token_value () =
     let loc = Location.curr lexbuf in
     match token () with

--- a/parsing/rescript_cpp.ml
+++ b/parsing/rescript_cpp.ml
@@ -310,7 +310,7 @@ let directive_parse (token_with_comments : Lexing.lexbuf -> Parser.token) lexbuf
     match curr_token with
     | RPAREN as e ->
         push e;
-        els
+        List.rev els
     | COMMA -> parse_tuple els ()
     | _ as e ->
         push e;

--- a/parsing/rescript_cpp.ml
+++ b/parsing/rescript_cpp.ml
@@ -292,6 +292,7 @@ let directive_parse (token_with_comments : Lexing.lexbuf -> Parser.token) lexbuf
           | LESS -> ( < )
           | GREATER -> ( > )
           | INFIXOP0 "<=" -> ( <= )
+          | INFIXOP0 ">=" -> ( >= )
           | EQUAL -> ( = )
           | INFIXOP0 "<>" -> ( <> )
           | _ -> assert false

--- a/parsing/rescript_cpp.ml
+++ b/parsing/rescript_cpp.ml
@@ -221,12 +221,11 @@ let coerce_type (lexbuf : Lexing.lexbuf) (lhs : directive_value) (rhs : directiv
   | _ -> assert_same_type lexbuf lhs rhs
 
 let rec pp_directive_value fmt (x : directive_value) =
-  let open Format in
   match x with
-  | Dir_bool b -> pp_print_bool fmt b
-  | Dir_int b -> pp_print_int fmt b
-  | Dir_float b -> pp_print_float fmt b
-  | Dir_string s -> fprintf fmt "%S" s
+  | Dir_bool b -> Format.pp_print_bool fmt b
+  | Dir_int b -> Format.pp_print_int fmt b
+  | Dir_float b -> Format.pp_print_float fmt b
+  | Dir_string s -> Format.fprintf fmt "%S" s
   | Dir_tuple els ->
     pp_open_box fmt 0;
     pp_print_string fmt "(";
@@ -236,7 +235,7 @@ let rec pp_directive_value fmt (x : directive_value) =
     ) pp_directive_value fmt els;
     pp_print_string fmt ")";
     pp_close_box fmt ()
-  | Dir_null -> pp_print_string fmt "null"
+  | Dir_null -> Format.pp_print_string fmt "null"
 
 let list_variables fmt =
   iter_directive_built_in_value (fun s dir_value ->
@@ -306,8 +305,7 @@ let directive_parse (token_with_comments : Lexing.lexbuf -> Parser.token) lexbuf
     look_ahead := Some e
   in
   let rec parse_tuple (els : directive_value list) () : directive_value list =
-    let curr_token = token () in
-    match curr_token with
+    match token () with
     | RPAREN as e ->
         push e;
         List.rev els


### PR DESCRIPTION
This PR implements a tiny bit more of cppo's language in `rescript_cpp` — just enough to support the "version-comparison" style used by non-BuckleScript-universe projects.

After this PR, the _specific_ invocation of the following form is supported (in addition to the existing BuckleScript-style semver comparison):

```ocaml
(* BuckleScript-style, *)
#if "4.08.0" =~ ">=4.08.0"
  print_endline "good job :patpat:";
#else
  this_should_never_be_seen
#endif

(* Old-school cppo-style, added by this PR *)
#if "4.08.0" >= (4, 08, 0)
  print_endline "good job :patpat:";
#else
  this_should_never_be_seen
#endif
```

This is implemented as a naive 'type-coercion' in one very specific circumstance. Intentional constraints include:

1. The new tuple-type is only accepted in a comparison operator;
2. it may only appear on the right-hand side;
3. only strings appearing on the left-hand-side of a coercion with a literal tuple will be coerced into such tuples;
4. and only strings containing a valid semver declaration (such as `OCAML_VERSION`) will be accepted.

(Also, although the _parser_ is a little more flexible for future-compatibility and safety, only _specifically_ tuples-of-three-integers are currently allowed as comparative payloads.)

This should fix `ppx_deriving`'s build under Melange, as it's [used there](https://github.com/ocaml-ppx/ppx_deriving/blob/b4896214b047dc750184feb474331e2ba626f2b1/src/runtime/ppx_deriving_runtime.cppo.mli#L25):

```ocaml
#if OCAML_VERSION >= (4, 07, 0)
include module type of struct
  include Stdlib
end
(* ... *)
```

Another usage in the wild [is in `lwt_unix.cppo.ml`](https://github.com/ocsigen/lwt/blob/fbd4fc52/src/unix/lwt_unix.cppo.ml#L2437), although for obvious reasons that may never pass through the Melange compiler.