### PR TITLE
Remove `Config.syntax_kind`

### DIFF
--- a/utils/config.ml
+++ b/utils/config.ml
@@ -31,7 +31,6 @@ let standard_library =
     standard_library_default
 let bs_only = ref false
 let unsafe_empty_array = ref true
-let syntax_kind = ref `ml
 let ccomp_type = "cc"
 let c_compiler = "clang"
 let c_output_obj = "-o "

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -29,8 +29,6 @@ val version: string
 val standard_library: string
 (** The directory containing the standard libraries *)
 
-val syntax_kind : [ `ml | `reason | `rescript ] ref
-
 val bs_only : bool ref
 
 val unsafe_empty_array: bool ref

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -895,13 +895,8 @@ let message = function
       "this statement never returns (or has an unsound type.)"
   | Preprocessor s -> s
   | Useless_record_with ->
-     begin match !Config.syntax_kind with
-      | `ml ->
       "all the fields are explicitly listed in this record:\n\
        the 'with' clause is useless."
-      | `reason | `rescript ->
-        "All the fields are already explicitly listed in this record. You can remove the `...` spread."
-     end
   | Bad_module_name (modname) ->
       "bad source file name: \"" ^ modname ^ "\" is not a valid module name."
   | All_clauses_guarded ->


### PR DESCRIPTION
In an effort to separate "syntaxes" from the compiler.