### PR TITLE
Re-enable `Levent`

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -177,10 +177,10 @@ let event_after ~scopes exp lam =
   Translprim.event_after (of_location ~scopes exp.exp_loc) exp lam
 
 let event_function ~scopes exp lam =
-  if !Bs_clflags.record_event_when_debug && !Clflags.debug && not !Config.bs_only then
+  if !Bs_clflags.record_event_when_debug && !Clflags.debug then
     let repr = Some (ref 0) in
     let (info, body) = lam repr in
-    (info,
+    (if !Config.bs_only then lam None else info,
      Levent(body, {lev_loc = of_location ~scopes exp.exp_loc;
                    lev_kind = Lev_function;
                    lev_repr = repr;

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -35,7 +35,7 @@ exception Error of Location.t * error
 let event_before loc exp lam = match lam with
 | Lstaticraise (_,_) -> lam
 | _ ->
-  if !Bs_clflags.record_event_when_debug && !Clflags.debug && not !Config.bs_only
+  if !Bs_clflags.record_event_when_debug && !Clflags.debug
   then Levent(lam, {lev_loc = loc;
                     lev_kind = Lev_before;
                     lev_repr = None;
@@ -43,7 +43,7 @@ let event_before loc exp lam = match lam with
   else lam
 
 let event_after loc exp lam =
-  if !Bs_clflags.record_event_when_debug && !Clflags.debug && not !Config.bs_only
+  if !Bs_clflags.record_event_when_debug && !Clflags.debug
   then Levent(lam, {lev_loc = loc;
                     lev_kind = Lev_after exp.exp_type;
                     lev_repr = None;


### PR DESCRIPTION
- `Levent` contains important location information that needs to be propagated for source map generation