### PR TITLE
Translmod: reset exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _build
+_opam
+.vscode

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1774,6 +1774,7 @@ let () =
     )
 
 let reset () =
+  export_identifiers := [];
   primitive_declarations := [];
   transl_store_subst := Ident.Map.empty;
   aliased_idents := Ident.empty;


### PR DESCRIPTION
There was some missing ref not being reset on `Translmod.reset`. This was causing trouble while testing the playground (see https://github.com/melange-re/melange/pull/538#issuecomment-1566991784).

I could notice the `export_identifiers` value was being reset [in the commit](https://github.com/jchavarri/rescript-compiler/commit/49bdd8fbbc6e5e6713b4e42fff3704d0963b2a9e#diff-aa5ed5529cd6e2ed01e117e63fe0ad1771506e64310560e5d6e6d5f16e216272R754) where rescript compiler "imported" the compiler libs in its main repo.

If one follows the commit of the submodule that rescript-compiler was using for the `ocaml` vendored folder ([961c468](https://github.com/rescript-lang/ocaml/tree/961c46861076f188c66a86a9bdf321a9c834a4e9)), the value can be found over there as well:

https://github.com/rescript-lang/ocaml/blob/961c46861076f188c66a86a9bdf321a9c834a4e9/bytecomp/translmod.ml#L754

The line was added [in 2018](https://github.com/rescript-lang/ocaml/commit/c3a1539d2dabfb8f13bff26eb4adf2edd6ade388), so I am not sure which commit `melange-compiler-libs` followed for the original import, but it was missing it.