### PR TITLE
Print `@u` instead of `@bs` & fix printing of `mel.this` and `mel.meth`

### DIFF
--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -305,7 +305,7 @@ and print_simple_out_type ppf =
           Otyp_arrow ("", Otyp_constr (Oide_ident { printed_name = "unit" }, []),tyl)
         else tyl
       in
-          fprintf ppf "@[<0>(%a@ [@bs])@]" print_out_type_1 res
+          fprintf ppf "@[<0>(%a@ [@u])@]" print_out_type_1 res
   | Otyp_constr (Oide_dot (Oide_dot (Oide_ident { printed_name = "Js_OO" }, "Meth" ),name),
         [tyl])
     ->
@@ -314,11 +314,11 @@ and print_simple_out_type ppf =
           Otyp_arrow ("", Otyp_constr (Oide_ident { printed_name = "unit" }, []),tyl)
         else tyl
       in
-      fprintf ppf "@[<0>(%a@ [@bs.meth])@]" print_out_type_1 res
+      fprintf ppf "@[<0>(%a@ [@mel.meth])@]" print_out_type_1 res
   | Otyp_constr (Oide_dot (Oide_dot (Oide_ident { printed_name = "Js_OO" }, "Callback" ), _),
                  [tyl])
     ->
-      fprintf ppf "@[<0>(%a@ [@bs.this])@]" print_out_type_1 tyl
+      fprintf ppf "@[<0>(%a@ [@mel.this])@]" print_out_type_1 tyl
   | Otyp_constr (id, tyl) ->
       pp_open_box ppf 0;
       print_typargs ppf tyl;

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -306,7 +306,7 @@ and print_simple_out_type ppf =
         else tyl
       in
           fprintf ppf "@[<0>(%a@ [@u])@]" print_out_type_1 res
-  | Otyp_constr (Oide_dot (Oide_dot (Oide_ident { printed_name = "Js_OO" }, "Meth" ),name),
+  | Otyp_constr (Oide_dot (Oide_dot (Oide_dot (Oide_dot (Oide_ident { printed_name = "Js" }, "Private" ), "Js_OO" ), "Meth" ),name),
         [tyl])
     ->
       let res =
@@ -315,8 +315,8 @@ and print_simple_out_type ppf =
         else tyl
       in
       fprintf ppf "@[<0>(%a@ [@mel.meth])@]" print_out_type_1 res
-  | Otyp_constr (Oide_dot (Oide_dot (Oide_ident { printed_name = "Js_OO" }, "Callback" ), _),
-                 [tyl])
+  | Otyp_constr (Oide_dot (Oide_dot (Oide_dot (Oide_dot (Oide_ident { printed_name = "Js" }, "Private" ), "Js_OO" ), "Callback" ), _),
+      [tyl])
     ->
       fprintf ppf "@[<0>(%a@ [@mel.this])@]" print_out_type_1 tyl
   | Otyp_constr (id, tyl) ->


### PR DESCRIPTION
A continuation from #29.

- Tackles the issue with `@bs` attribute appearing in errors, mentioned in https://github.com/melange-re/melange/issues/747#issuecomment-1745157666.
- Updates the references to `Js_OO`, which changed in https://github.com/melange-re/melange/pull/798.